### PR TITLE
Adjusted to Python 3

### DIFF
--- a/example/basic_render.py
+++ b/example/basic_render.py
@@ -6,7 +6,8 @@ from json_map import Map
 window = pyglet.window.Window()
 
 # load the map
-fd = pyglet.resource.file("map.json")
+fd = pyglet.resource.file("map.json", 'rt')
+print("{0}".format(fd))
 m = Map.load_json(fd)
 
 # set the viewport to the window dimensions
@@ -15,26 +16,26 @@ m.set_viewport(0, 0, window.width, window.height)
 # perform some queries to the map data!
 
 # list all the objects
-print "listing all the objects:"
+print("listing all the objects:")
 for obj in m.objectgroups["Objects"]:
-    print obj
+    print(obj)
 
 # is there a "Door1" object?
-print "Door1" in m.objectgroups["Objects"]
+print("Door1" in m.objectgroups["Objects"])
 
 # is there aan object in coords 10, 10?
-print (0, 10) in m.objectgroups["Objects"]
+print((0, 10) in m.objectgroups["Objects"])
 
 # get the object named "Door1"
-print "Door1:", m.objectgroups["Objects"]["Door1"]
+print("Door1:", m.objectgroups["Objects"]["Door1"])
 
 # get the object in coords (5, 3)
-print "Obj ar (5, 3)", m.objectgroups["Objects"][5, 3]
+print("Obj ar (5, 3)", m.objectgroups["Objects"][5, 3])
 
 # list all the objects with type "Door":
-print "listing all the Door objects:"
+print("listing all the Door objects:")
 for obj in m.objectgroups["Objects"].get_by_type("Door"):
-    print obj
+    print(obj)
 
 @window.event
 def on_draw():
@@ -42,4 +43,3 @@ def on_draw():
     m.draw()
 
 pyglet.app.run()
-

--- a/example/basic_render.py
+++ b/example/basic_render.py
@@ -7,7 +7,6 @@ window = pyglet.window.Window()
 
 # load the map
 fd = pyglet.resource.file("map.json", 'rt')
-print("{0}".format(fd))
 m = Map.load_json(fd)
 
 # set the viewport to the window dimensions

--- a/json_map.py
+++ b/json_map.py
@@ -44,8 +44,8 @@ def get_texture_sequence(filename, tilewidth=32, tileheight=32, margin=1, spacin
     image = pyglet.resource.image(filename)
     region = image.get_region(margin, margin, image.width-margin*2, image.height-margin*2)
     grid = pyglet.image.ImageGrid(region,
-                                  region.height/tileheight,
-                                  region.width/tilewidth,
+                                  int(region.height/tileheight),
+                                  int(region.width/tilewidth),
                                   row_padding=spacing,
                                   column_padding=spacing,
                                   )


### PR DESCRIPTION
Hello, the example didn't work in Python 3, most likely from two differences; the dimension of TextureGrid did not accept float, and the pyglet.resource.file(...) required 'rt' mode to interpret the JSON file as str and not bytes. Not sure if you want to replace the existing one if it works for 2.# but, perhaps mention it in the README for those who come after :) Took me a little while to figure out, so thought I'd save someone the trouble.
